### PR TITLE
✨ [+feature]  additional_dependencies for files outside of config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![CI](https://github.com/davidbrownell/AutoGitSemVer/actions/workflows/standard.yaml/badge.svg?event=push)](https://github.com/davidbrownell/AutoGitSemVer/actions/workflows/standard.yaml)
 [![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/davidbrownell/f15146b1b8fdc0a5d45ac0eb786a84f7/raw/AutoGitSemVer_coverage.json)](https://github.com/davidbrownell/AutoGitSemVer/actions)
-[![GitHub](https://img.shields.io/github/license/davidbrownell/AutoGitSemVer?color=dark-green)](https://github.com/davidbrownell/AutoGitSemVer/blob/master/LICENSE_1_0.txt)
+[![License](https://img.shields.io/github/license/davidbrownell/AutoGitSemVer?color=dark-green)](https://github.com/davidbrownell/AutoGitSemVer/blob/master/LICENSE_1_0.txt)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/y/davidbrownell/AutoGitSemVer?color=dark-green)](https://github.com/davidbrownell/AutoGitSemVer/commits/main/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/AutoGitSemVer?color=dark-green)](https://pypi.org/project/autogitsemver/)
 [![PyPI - Version](https://img.shields.io/pypi/v/AutoGitSemVer?color=dark-green)](https://pypi.org/project/autogitsemver/)
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/AutoGitSemVer)](https://pypi.org/project/autogitsemver/)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/y/davidbrownell/AutoGitSemVer?color=dark-green)](https://github.com/davidbrownell/AutoGitSemVer/commits/main/)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/AutoGitSemVer)](https://pypistats.org/packages/autogitsemver)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dynamic = [
     "version",
 ]
 
+readme = "README.md"
+
 [project.optional-dependencies]
 dev = [
     "dbrownell_DevTools",

--- a/src/AutoGitSemVer.yaml
+++ b/src/AutoGitSemVer.yaml
@@ -1,3 +1,3 @@
-{
-  initial_version: 0.1.0
-}
+additional_dependencies:
+  - "../pyproject.toml"
+  - "../README.md"

--- a/src/AutoGitSemVer/AutoGitSemVerSchema.json
+++ b/src/AutoGitSemVer/AutoGitSemVerSchema.json
@@ -1,20 +1,11 @@
 {
   "$schema" : "https://json-schema.org/draft/2020-12/schema#",
-  "$defs" : {
-    "__ItemStatement-Ln56-Item-Ln56" : {
-      "type" : "string",
-      "minLength" : 1
-    },
-    "__ItemStatement-Ln86-Item-Ln86" : {
-      "type" : "string",
-      "minLength" : 1
-    }
-  },
   "type" : "object",
   "additionalProperties" : false,
   "properties" : {
     "version_prefix" : {
-      "$ref" : "#/$defs/__ItemStatement-Ln56-Item-Ln56",
+      "type" : "string",
+      "minLength" : 1,
       "description" : "String that serves as a prefix before the version; this functionality can be used in the support of distinct versions within the same repository.",
       "default" : null
     },
@@ -48,7 +39,8 @@
     "main_branch_names" : {
       "type" : "array",
       "items" : {
-        "$ref" : "#/$defs/__ItemStatement-Ln86-Item-Ln86"
+        "type" : "string",
+        "minLength" : 1
       },
       "minItems" : 1,
       "description" : "Name of branches considered to be 'mainline' branches; branch information will not be included in the generated semantic version.",
@@ -57,6 +49,18 @@
         "master",
         "default"
       ]
+    },
+    "additional_dependencies" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "minLength" : 1,
+        "__custom__" : {
+          "ensure_exists" : true,
+          "match_any" : true
+        }
+      },
+      "description" : "Normally, commits to files in this directory and below are used to calculate semantic versions. Sometimes, additional file and directory dependencies outside of this directory must be considered as well. Define those dependencies here."
     }
   },
   "required" : [

--- a/src/ConfigurationSchema/AutoGitSemVerSchema.SimpleSchema
+++ b/src/ConfigurationSchema/AutoGitSemVerSchema.SimpleSchema
@@ -14,12 +14,12 @@
 # |
 # ----------------------------------------------------------------------
 
-# Configuration file for AutoSemVer. Place json files anywhere under a repository to modify how
+# Configuration file for AutoGitSemVer. Place json files anywhere under a repository to modify how
 # semantic versions are generated.
 #
 # To generate a single sematic version for the entire repository:
 #
-#    - Place a single configuration file in the root of the repository (e.g. `<repo_root>/AutoSemVer.json`) -
+#    - Place a single configuration file in the root of the repository (e.g. `<repo_root>/AutoGitSemVer.json`) -
 #
 #        - or -
 #
@@ -30,13 +30,13 @@
 #
 #    <repo_root>
 #    |-- Directory1
-#    |   |-- AutoSemVer.json
+#    |   |-- AutoGitSemVer.json
 #    |   |-- <Semantic versions based on changes to any files in this directory or its descendants
-#    |   |    will be controlled by this AutoSemVer.json file>
+#    |   |    will be controlled by this AutoGitSemVer.json file>
 #    |-- Directory2
-#    |   |-- AutoSemVer.json
+#    |   |-- AutoGitSemVer.json
 #    |   |-- <Semantic versions based on changes to any files in this directory or its descendants
-#    |   |    will be controlled by this AutoSemVer.json file>
+#    |   |    will be controlled by this AutoGitSemVer.json file>
 #    |-- <Changes in this directory will not impact either semantic version>
 #
 
@@ -90,4 +90,10 @@ main_branch_names: String+ {
         "default",
     ]
     description: "Name of branches considered to be 'mainline' branches; branch information will not be included in the generated semantic version."
+}
+
+additional_dependencies: Filename* {
+    ensure_exists: true
+    match_any: true
+    description: "Normally, commits to files in this directory and below are used to calculate semantic versions. Sometimes, additional file and directory dependencies outside of this directory must be considered as well. Define those dependencies here."
 }

--- a/tests/Lib_UnitTest.py
+++ b/tests/Lib_UnitTest.py
@@ -134,10 +134,17 @@ class TestGetConfiguration:
             configuration.prerelease_environment_variable_name == "AUTO_GIT_SEM_VER_PRERELEASE_NAME"
         )
         assert configuration.version_prefix is None
+        assert configuration.additional_dependencies == []
 
     # ----------------------------------------------------------------------
     def test_Yaml(self, tmp_path_factory):
         root = tmp_path_factory.mktemp("root")
+
+        with (root / "one").open("w") as f:
+            pass
+
+        with (root / "two").open("w") as f:
+            pass
 
         with (root / "AutoGitSemVer.yaml").open("w") as f:
             f.write(
@@ -150,6 +157,7 @@ class TestGetConfiguration:
                         initial_version: 1.2.3,
                         main_branch_names: [ "foo", "bar" ],
                         prerelease_environment_variable_name: "BAZ",
+                        additional_dependencies: ["one", "two"]
                     }
                     """,
                 ),
@@ -165,6 +173,7 @@ class TestGetConfiguration:
         assert configuration.main_branch_names == ["foo", "bar"]
         assert configuration.prerelease_environment_variable_name == "BAZ"
         assert configuration.version_prefix is None
+        assert configuration.additional_dependencies == [root / "one", root / "two"]
 
     # ----------------------------------------------------------------------
     def test_Yml(self, tmp_path_factory):
@@ -195,6 +204,7 @@ class TestGetConfiguration:
             configuration.prerelease_environment_variable_name == "AUTO_GIT_SEM_VER_PRERELEASE_NAME"
         )
         assert configuration.version_prefix == "Test-v"
+        assert configuration.additional_dependencies == []
 
     # ----------------------------------------------------------------------
     def test_Json(self, tmp_path_factory):
@@ -223,6 +233,7 @@ class TestGetConfiguration:
             configuration.prerelease_environment_variable_name == "AUTO_GIT_SEM_VER_PRERELEASE_NAME"
         )
         assert configuration.version_prefix is None
+        assert configuration.additional_dependencies == []
 
     # ----------------------------------------------------------------------
     def test_Invalid(self, tmp_path_factory):
@@ -387,7 +398,7 @@ class TestSemanticVersion:
         assert result == 0
         assert semver.major == 0
         assert semver.minor == 1
-        assert semver.patch == 3
+        assert semver.patch == 2
 
     # ----------------------------------------------------------------------
     def test_Styles(self):


### PR DESCRIPTION
Additional files can be specified in AutoGitSemVer.yaml to indicate that changes outside of the configuration file's directory should indicate a bump in semantic version.